### PR TITLE
fix: Fixed code formating for python3.8, changed python version durin…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.8"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/poetry_plugin_lambda_build/docker.py
+++ b/poetry_plugin_lambda_build/docker.py
@@ -9,7 +9,7 @@ from typing import Generator
 import docker
 from docker.models.containers import Container
 
-from poetry_plugin_lambda_build.utils import cd
+from poetry_plugin_lambda_build.utils import cd, cmd_split
 
 
 def _parse_str_to_list(value: str) -> list[str]:
@@ -85,19 +85,22 @@ def run_container(logger, **kwargs) -> Generator[Container, None, None]:
 
 
 def exec_run_container(
-    logger, container: Container, entrypoint: str, container_cmd: list[str]
+    logger, container: Container, container_cmd: list[str], print_safe_cmds: list[str]
 ):
-    cmd = " ".join(container_cmd)
-    exit_code, stream = container.exec_run(
-        f'{entrypoint} -c "{cmd}"',
-        stdout=True,
-        stderr=True,
-        stream=True,
-    )
-    for line in stream:
-        logger.info(line.strip().decode())
-
-    if exit_code and exit_code != 0:
-        raise RuntimeError(
-            f"Exec run in container resulted with exit code: {exit_code}"
+    for cmd, print_safe_cmd in zip(
+        cmd_split(container_cmd), cmd_split(print_safe_cmds)
+    ):
+        logger.debug(f"Executing: {' '.join(print_safe_cmd)}")
+        exit_code, stream = container.exec_run(
+            cmd,
+            stdout=True,
+            stderr=True,
+            stream=True,
         )
+        for line in stream:
+            logger.info(line.strip().decode())
+
+        if exit_code and exit_code != 0:
+            raise RuntimeError(
+                f"Exec run in container resulted with exit code: {exit_code}"
+            )

--- a/poetry_plugin_lambda_build/docker.py
+++ b/poetry_plugin_lambda_build/docker.py
@@ -87,8 +87,9 @@ def run_container(logger, **kwargs) -> Generator[Container, None, None]:
 def exec_run_container(
     logger, container: Container, entrypoint: str, container_cmd: list[str]
 ):
+    cmd = " ".join(container_cmd)
     exit_code, stream = container.exec_run(
-        f'{entrypoint} -c "{' '.join(container_cmd)}"',
+        f'{entrypoint} -c "{cmd}"',
         stdout=True,
         stderr=True,
         stream=True,

--- a/poetry_plugin_lambda_build/parameters.py
+++ b/poetry_plugin_lambda_build/parameters.py
@@ -135,7 +135,7 @@ ARGS = {
         True,
         False,
         None,
-        str,
+        lambda x: x.split(" "),
     ),
 }
 

--- a/poetry_plugin_lambda_build/recipes.py
+++ b/poetry_plugin_lambda_build/recipes.py
@@ -180,7 +180,7 @@ class Builder:
             format_cmd(
                 string,
                 package_name=self.cmd.poetry.package.name,
-                indexes=mask_string(indexes),
+                indexes=mask_string(" ".join(indexes)),
                 **kwargs,
             )
         )
@@ -197,13 +197,10 @@ class Builder:
             )
             self.cmd.info("Installing requirements")
 
-            if self.parameters.get("pre-install-script"):
-                install_deps_cmd_in_container_tmpl = join_cmds(
-                    self.parameters.get("pre_install_script"),
-                    INSTALL_DEPS_CMD_IN_CONTAINER_TMPL,
-                )
-            else:
-                install_deps_cmd_in_container_tmpl = INSTALL_DEPS_CMD_IN_CONTAINER_TMPL
+            install_deps_cmd_in_container_tmpl = join_cmds(
+                self.parameters.get("pre-install-script"),
+                INSTALL_DEPS_CMD_IN_CONTAINER_TMPL,
+            )
 
             cmd, print_safe_cmd = self.format_cmd(
                 install_deps_cmd_in_container_tmpl,
@@ -293,15 +290,10 @@ class Builder:
             self.cmd, **self.parameters.get_section("docker"), working_dir="/"
         ) as container:
             copy_to_container(src=f"{CURRENT_WORK_DIR}/.", dst=f"{container.id}:/")
-            if self.parameters.get("pre-install-script"):
-                install_in_container_no_deps_cmd_tmpl = join_cmds(
-                    self.parameters.get("pre-install-script"),
-                    INSTALL_IN_CONTAINER_NO_DEPS_CMD_TMPL,
-                )
-            else:
-                install_in_container_no_deps_cmd_tmpl = (
-                    INSTALL_IN_CONTAINER_NO_DEPS_CMD_TMPL
-                )
+            install_in_container_no_deps_cmd_tmpl = join_cmds(
+                self.parameters.get("pre-install-script"),
+                INSTALL_IN_CONTAINER_NO_DEPS_CMD_TMPL,
+            )
 
             cmd, print_safe_cmd = self.format_cmd(
                 install_in_container_no_deps_cmd_tmpl, output_dir=CONTAINER_CACHE_DIR
@@ -318,12 +310,10 @@ class Builder:
     def _build_separated_function_on_local(self, package_dir: str):
         os.makedirs(package_dir, exist_ok=True)
 
-        if self.parameters.get("pre-install-script"):
-            install_no_deps_cmd_tmpl = join_cmds(
-                self.parameters.get("pre-install-script"), INSTALL_NO_DEPS_CMD_TMPL
-            )
-        else:
-            install_no_deps_cmd_tmpl = INSTALL_NO_DEPS_CMD_TMPL
+        install_no_deps_cmd_tmpl = join_cmds(
+            self.parameters.get("pre-install-script"), INSTALL_NO_DEPS_CMD_TMPL
+        )
+
         cmd, print_safe_cmd = self.format_cmd(
             install_no_deps_cmd_tmpl,
             output_dir=package_dir,
@@ -362,13 +352,10 @@ class Builder:
             self.cmd.info("Coping content")
             copy_to_container(f"{CURRENT_WORK_DIR}/.", f"{container.id}:/")
 
-            if self.parameters.get("pre-install-script"):
-                install_in_container_cmd_tmpl = join_cmds(
-                    self.parameters.get("pre-install-script"),
-                    INSTALL_IN_CONTAINER_CMD_TMPL,
-                )
-            else:
-                install_in_container_cmd_tmpl = INSTALL_IN_CONTAINER_CMD_TMPL
+            install_in_container_cmd_tmpl = join_cmds(
+                self.parameters.get("pre-install-script"),
+                INSTALL_IN_CONTAINER_CMD_TMPL,
+            )
 
             cmd, print_safe_cmd = self.format_cmd(
                 install_in_container_cmd_tmpl,
@@ -390,12 +377,9 @@ class Builder:
     def _build_package_on_local(self, package_dir: str):
         self.cmd.info("Building package on local")
 
-        if self.parameters.get("pre-install-script"):
-            install_cmd_tmpl = join_cmds(
-                self.parameters.get("pre-install-script"), INSTALL_CMD_TMPL
-            )
-        else:
-            install_cmd_tmpl = INSTALL_CMD_TMPL
+        install_cmd_tmpl = join_cmds(
+            self.parameters.get("pre-install-script"), INSTALL_CMD_TMPL
+        )
 
         cmd, print_safe_cmd = self.format_cmd(install_cmd_tmpl, output_dir=package_dir)
         self.cmd.debug(f"Executing: {print_safe_cmd}")

--- a/poetry_plugin_lambda_build/recipes.py
+++ b/poetry_plugin_lambda_build/recipes.py
@@ -30,7 +30,7 @@ from poetry_plugin_lambda_build.utils import (
     join_cmds,
     mask_string,
     remove_suffix,
-    run_cmd
+    run_cmd,
 )
 from poetry_plugin_lambda_build.zip import create_zip_package
 
@@ -140,14 +140,12 @@ def verify_checksum(param):
                 if is_zip:
                     with zipfile.ZipFile(target, "a") as zipf:
                         zipf.write(
-                            checksum_file_path, os.path.join(
-                                install_dir, "checksum")
+                            checksum_file_path, os.path.join(install_dir, "checksum")
                         )
                 else:
                     shutil.copyfile(
                         checksum_file_path,
-                        os.path.join(CURRENT_WORK_DIR, target,
-                                     install_dir, "checksum"),
+                        os.path.join(CURRENT_WORK_DIR, target, install_dir, "checksum"),
                     )
 
             return retval
@@ -256,8 +254,7 @@ class Builder:
             install_dir = self.parameters.get("layer-install-dir", "")
             layer_output_dir = os.path.join(tmp_dir, "layer-output")
             target = os.path.join(
-                CURRENT_WORK_DIR, self.parameters.get(
-                    "layer-artifact-path", "")
+                CURRENT_WORK_DIR, self.parameters.get("layer-artifact-path", "")
             )
             requirements_path = os.path.join(tmp_dir, "requirements.txt")
             layer_output_dir = os.path.join(layer_output_dir, install_dir)
@@ -292,8 +289,7 @@ class Builder:
         with run_container(
             self.cmd, **self.parameters.get_section("docker"), working_dir="/"
         ) as container:
-            copy_to_container(
-                src=f"{CURRENT_WORK_DIR}/.", dst=f"{container.id}:/")
+            copy_to_container(src=f"{CURRENT_WORK_DIR}/.", dst=f"{container.id}:/")
             install_in_container_no_deps_cmd_tmpl = join_cmds(
                 self.parameters.get("pre-install-script"),
                 INSTALL_IN_CONTAINER_NO_DEPS_CMD_TMPL,
@@ -335,8 +331,7 @@ class Builder:
             install_dir = self.parameters.get("function-install-dir", "")
             package_dir = tmp_dir
             target = os.path.join(
-                CURRENT_WORK_DIR, self.parameters.get(
-                    "function-artifact-path", "")
+                CURRENT_WORK_DIR, self.parameters.get("function-artifact-path", "")
             )
             package_dir = os.path.join(package_dir, install_dir)
             if self.in_container:
@@ -392,8 +387,7 @@ class Builder:
             self.cmd.debug(f"Executing: {print_safe_cmd}")
             run_cmd(*cmd, logger=self.cmd)
 
-        cmd, print_safe_cmd = self.format_cmd(
-            INSTALL_CMD_TMPL, output_dir=package_dir)
+        cmd, print_safe_cmd = self.format_cmd(INSTALL_CMD_TMPL, output_dir=package_dir)
         self.cmd.debug(f"Executing: {print_safe_cmd}")
         run_cmd(*cmd, logger=self.cmd)
 
@@ -405,8 +399,7 @@ class Builder:
             package_dir = os.path.join(tmp_dir, install_dir)
             os.makedirs(package_dir, exist_ok=True)
             target = os.path.join(
-                CURRENT_WORK_DIR, self.parameters.get(
-                    "package-artifact-path", "")
+                CURRENT_WORK_DIR, self.parameters.get("package-artifact-path", "")
             )
 
             if self.in_container:

--- a/poetry_plugin_lambda_build/recipes.py
+++ b/poetry_plugin_lambda_build/recipes.py
@@ -27,14 +27,13 @@ from poetry_plugin_lambda_build.parameters import ParametersContainer
 from poetry_plugin_lambda_build.requirements import RequirementsExporter
 from poetry_plugin_lambda_build.utils import (
     format_cmd,
-    join_cmds,
     mask_string,
     remove_suffix,
-    run_cmd,
+    run_cmds,
+    join_cmds,
 )
 from poetry_plugin_lambda_build.zip import create_zip_package
-
-from .utils import compute_checksum
+from poetry_plugin_lambda_build.utils import compute_checksum
 
 CONTAINER_CACHE_DIR = "/opt/lambda/cache"
 CURRENT_WORK_DIR = os.getcwd()
@@ -170,20 +169,21 @@ class Builder:
 
     def format_cmd(self, string: str, **kwargs) -> tuple[list[str], str]:
         indexes = get_indexes(self.cmd, self.parameters)
-
-        return format_cmd(
+        cmd = format_cmd(
             string,
             package_name=self.cmd.poetry.package.name,
             indexes=indexes,
             **kwargs,
-        ), " ".join(
-            format_cmd(
-                string,
-                package_name=self.cmd.poetry.package.name,
-                indexes=mask_string(" ".join(indexes)),
-                **kwargs,
-            )
         )
+
+        print_safe_cmd = format_cmd(
+            string,
+            package_name=self.cmd.poetry.package.name,
+            indexes=mask_string(" ".join(indexes)),
+            **kwargs,
+        )
+
+        return cmd, print_safe_cmd
 
     def _build_separate_layer_in_container(
         self, requirements_path: str, layer_output_dir: str
@@ -201,18 +201,17 @@ class Builder:
                 self.parameters.get("pre-install-script"),
                 INSTALL_DEPS_CMD_IN_CONTAINER_TMPL,
             )
-
             cmd, print_safe_cmd = self.format_cmd(
                 install_deps_cmd_in_container_tmpl,
                 output_dir=CONTAINER_CACHE_DIR,
                 requirements="/requirements.txt",
             )
-            self.cmd.debug(f"Executing: {print_safe_cmd}")
+
             exec_run_container(
                 logger=self.cmd,
                 container=container,
-                entrypoint=self.parameters["docker-entrypoint"],
                 container_cmd=cmd,
+                print_safe_cmds=print_safe_cmd,
             )
             self.cmd.info(f"Coping output to {layer_output_dir}")
             copy_from_container(
@@ -244,8 +243,8 @@ class Builder:
             output_dir=layer_output_dir,
             requirements=requirements_path,
         )
-        self.cmd.info(f"Executing: {''.join(print_safe_cmd)}")
-        run_cmd(*cmd, logger=self.cmd)
+
+        run_cmds(cmds=cmd, print_safe_cmds=print_safe_cmd, logger=self.cmd)
 
     @verify_checksum("layer-artifact-path")
     def build_separate_layer_package(self):
@@ -290,6 +289,7 @@ class Builder:
             self.cmd, **self.parameters.get_section("docker"), working_dir="/"
         ) as container:
             copy_to_container(src=f"{CURRENT_WORK_DIR}/.", dst=f"{container.id}:/")
+
             install_in_container_no_deps_cmd_tmpl = join_cmds(
                 self.parameters.get("pre-install-script"),
                 INSTALL_IN_CONTAINER_NO_DEPS_CMD_TMPL,
@@ -299,10 +299,7 @@ class Builder:
                 install_in_container_no_deps_cmd_tmpl, output_dir=CONTAINER_CACHE_DIR
             )
 
-            self.cmd.info(f"Executing: {print_safe_cmd}")
-            exec_run_container(
-                self.cmd, container, self.parameters["docker-entrypoint"], cmd
-            )
+            exec_run_container(self.cmd, container, cmd, print_safe_cmd)
             copy_from_container(
                 src=f"{container.id}:{CONTAINER_CACHE_DIR}/.", dst=package_dir
             )
@@ -310,19 +307,15 @@ class Builder:
     def _build_separated_function_on_local(self, package_dir: str):
         os.makedirs(package_dir, exist_ok=True)
 
-        if self.parameters.get("pre-install-script"):
-            cmd, print_safe_cmd = self.format_cmd(
-                self.parameters.get("pre-install-script"),
-            )
-            self.cmd.debug(f"Executing: {print_safe_cmd}")
-            run_cmd(*cmd, logger=self.cmd)
-
+        install_no_deps_cmd_tmpl = join_cmds(
+            self.parameters.get("pre-install-script"), INSTALL_NO_DEPS_CMD_TMPL
+        )
         cmd, print_safe_cmd = self.format_cmd(
-            INSTALL_NO_DEPS_CMD_TMPL,
+            install_no_deps_cmd_tmpl,
             output_dir=package_dir,
         )
-        self.cmd.debug(f"Executing: {print_safe_cmd}")
-        run_cmd(*cmd, logger=self.cmd)
+
+        run_cmds(cmds=cmd, print_safe_cmds=print_safe_cmd, logger=self.cmd)
 
     @verify_checksum("function-artifact-path")
     def build_separated_function_package(self):
@@ -356,22 +349,18 @@ class Builder:
             copy_to_container(f"{CURRENT_WORK_DIR}/.", f"{container.id}:/")
 
             install_in_container_cmd_tmpl = join_cmds(
-                self.parameters.get("pre-install-script"),
-                INSTALL_IN_CONTAINER_CMD_TMPL,
+                self.parameters.get("pre-install-script"), INSTALL_IN_CONTAINER_CMD_TMPL
             )
-
             cmd, print_safe_cmd = self.format_cmd(
                 install_in_container_cmd_tmpl,
                 output_dir=CONTAINER_CACHE_DIR,
             )
 
-            self.cmd.debug(f"Executing: {print_safe_cmd}")
-
             exec_run_container(
                 logger=self.cmd,
                 container=container,
-                entrypoint=self.parameters["docker-entrypoint"],
                 container_cmd=cmd,
+                print_safe_cmds=print_safe_cmd,
             )
             copy_from_container(
                 src=f"{container.id}:{CONTAINER_CACHE_DIR}/.", dst=package_dir
@@ -380,16 +369,13 @@ class Builder:
     def _build_package_on_local(self, package_dir: str):
         self.cmd.info("Building package on local")
 
-        if self.parameters.get("pre-install-script"):
-            cmd, print_safe_cmd = self.format_cmd(
-                self.parameters.get("pre-install-script"),
-            )
-            self.cmd.debug(f"Executing: {print_safe_cmd}")
-            run_cmd(*cmd, logger=self.cmd)
+        install_cmd_tmpl = join_cmds(
+            self.parameters.get("pre-install-script"), INSTALL_CMD_TMPL
+        )
 
-        cmd, print_safe_cmd = self.format_cmd(INSTALL_CMD_TMPL, output_dir=package_dir)
-        self.cmd.debug(f"Executing: {print_safe_cmd}")
-        run_cmd(*cmd, logger=self.cmd)
+        cmd, print_safe_cmd = self.format_cmd(install_cmd_tmpl, output_dir=package_dir)
+
+        run_cmds(cmds=cmd, print_safe_cmds=print_safe_cmd, logger=self.cmd)
 
     @verify_checksum("package-artifact-path")
     def build_package(self):

--- a/poetry_plugin_lambda_build/requirements.py
+++ b/poetry_plugin_lambda_build/requirements.py
@@ -55,8 +55,7 @@ class RequirementsExporter:
                     for opt in sorted(invalid_options[group])
                 )
                 message_parts.append(f"{group} (via {opts})")
-            raise GroupNotFound(f"Group(s) not found: {
-                                ', '.join(message_parts)}")
+            raise GroupNotFound(f"Group(s) not found: {', '.join(message_parts)}")
 
     @property
     def activated_groups(self) -> set[str]:
@@ -85,8 +84,7 @@ class RequirementsExporter:
         if package.develop:
             if not allow_editable:
                 self._io.write_error_line(
-                    f"<warning>Warning: {
-                        package.pretty_name} is locked in develop"
+                    f"<warning>Warning: {package.pretty_name} is locked in develop"
                     " (editable) mode, which is incompatible with the"
                     " constraints.txt format.</warning>"
                 )

--- a/poetry_plugin_lambda_build/utils.py
+++ b/poetry_plugin_lambda_build/utils.py
@@ -72,7 +72,6 @@ def run_cmd(
             logger.error(error.decode())
         else:
             sys.stderr.write(error.decode())
-        print(args)
         raise RuntimeError(
             error.decode(),
             process.returncode,

--- a/poetry_plugin_lambda_build/utils.py
+++ b/poetry_plugin_lambda_build/utils.py
@@ -13,7 +13,10 @@ from pathlib import Path
 
 
 def join_cmds(*cmds: list[list[str]], joiner: str = " && ") -> list[str]:
-    return joiner.join([" ".join(cmd) for cmd in cmds]).split(" ")
+    split_marker = "----"
+    return joiner.join([split_marker.join(cmd) for cmd in cmds if cmd]).split(
+        split_marker
+    )
 
 
 @contextmanager

--- a/poetry_plugin_lambda_build/utils.py
+++ b/poetry_plugin_lambda_build/utils.py
@@ -10,10 +10,22 @@ from functools import reduce
 from logging import Logger
 from operator import or_
 from pathlib import Path
+from typing import Generator
 
 
 def join_cmds(*cmds: list[list[str]], joiner: str = " && ") -> list[str]:
     return joiner.join([" ".join(cmd) for cmd in cmds if cmd]).split(" ")
+
+
+def cmd_split(cmd: list[str], separator="&&") -> Generator[None, None, list[str]]:
+    result = []
+    for c in cmd:
+        if c == separator:
+            yield result
+            result = []
+        else:
+            result.append(c)
+    yield result
 
 
 @contextmanager
@@ -38,33 +50,20 @@ def mask_string(s: str) -> str:
     return f'{s[:14]}{"*" * len(s)}'
 
 
-def run_python_cmd(
-    *args: list[str],
-    logger: Logger | None = None,
-    stdout: int = subprocess.PIPE,
-    stderr: int = subprocess.PIPE,
-    **kwargs,
-) -> int:
-    return run_cmd(
-        sys.executable, *args, logger=logger, stdout=stdout, stderr=stderr, **kwargs
-    )
-
-
 def run_cmd(
-    *args: list[str],
+    *cmd: list[str],
     logger: Logger | None = None,
     stdout: int = subprocess.PIPE,
     stderr: int = subprocess.PIPE,
     **kwargs,
 ) -> int:
-    process = subprocess.Popen(args, stdout=stdout, stderr=stderr, **kwargs)
+    process = subprocess.Popen(cmd, stdout=stdout, stderr=stderr, **kwargs)
     if logger:
         while process.poll() is None:
             logger.info(process.stdout.readline().decode())
     else:
         while process.poll() is None:
             sys.stdout.write(process.stdout.readline().decode())
-
     _, error = process.communicate()
 
     if process.returncode != 0:
@@ -76,8 +75,20 @@ def run_cmd(
             error.decode(),
             process.returncode,
         )
-
     return process.returncode
+
+
+def run_cmds(
+    cmds: list[str],
+    print_safe_cmds: list[str],
+    logger: Logger,
+    stdout: int = subprocess.PIPE,
+    stderr: int = subprocess.PIPE,
+    **kwargs,
+) -> int:
+    for cmd, print_safe_cmd in zip(cmd_split(cmds), cmd_split(print_safe_cmds)):
+        logger.debug(f"Executing: {' '.join(print_safe_cmd)}")
+        run_cmd(*cmd, logger=logger, stdout=stdout, stderr=stderr, **kwargs)
 
 
 def format_cmd(cmd: list[str], **kwargs) -> list[str]:

--- a/poetry_plugin_lambda_build/utils.py
+++ b/poetry_plugin_lambda_build/utils.py
@@ -13,9 +13,8 @@ from pathlib import Path
 
 
 def join_cmds(*cmds: list[list[str]], joiner: str = " && ") -> list[str]:
-    split_marker = "----"
-    return joiner.join([split_marker.join(cmd) for cmd in cmds if cmd]).split(
-        split_marker
+    return joiner.join([" ".join(cmd) for cmd in cmds if cmd]).split(
+        " "
     )
 
 
@@ -75,6 +74,7 @@ def run_cmd(
             logger.error(error.decode())
         else:
             sys.stderr.write(error.decode())
+        print(args)
         raise RuntimeError(
             error.decode(),
             process.returncode,

--- a/poetry_plugin_lambda_build/utils.py
+++ b/poetry_plugin_lambda_build/utils.py
@@ -13,9 +13,7 @@ from pathlib import Path
 
 
 def join_cmds(*cmds: list[list[str]], joiner: str = " && ") -> list[str]:
-    return joiner.join([" ".join(cmd) for cmd in cmds if cmd]).split(
-        " "
-    )
+    return joiner.join([" ".join(cmd) for cmd in cmds if cmd]).split(" ")
 
 
 @contextmanager

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-plugin-lambda-build"
-version = "1.0.2"
+version = "1.0.3"
 description = "The plugin for poetry that allows you to build zip packages suited for serverless deployment like AWS Lambda, Google App Engine, Azure App Service, and more..."
 authors = ["Michal Murawski <mmurawski777@gmail.com>"]
 readme = "README.md"

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -197,12 +197,15 @@ def test_zip_builds(config: dict, args: dict, assert_files: list, tmp_path: Path
             open(handler_file, "w").close()
 
             if PYTHON_VER == "3.8":
-                config["pre-install-script"] = "pip install urllib3==1.26.7 -U -q"
+                config["pre-install-script"] = "python3 -m pip install urllib3==1.26.7 -U -q"
 
             if config:
                 update_pyproject_toml(**config)
             arguments = " ".join(f"{k}={v}" for k, v in args.items())
-            assert run_poetry_cmd("build-lambda", arguments, "-v") == 0
+            if arguments:
+                assert run_poetry_cmd("build-lambda", arguments, "-v") == 0
+            else:
+                assert run_poetry_cmd("build-lambda", "-v") == 0
             for files_assertion in assert_files:
                 files_assertion()
 
@@ -229,6 +232,9 @@ def test_dir_builds(config: dict, args: dict, assert_files: list, tmp_path: Path
             if config:
                 update_pyproject_toml(**config)
             arguments = " ".join(f"{k}={v}" for k, v in args.items())
-            assert run_poetry_cmd("build-lambda", arguments, "-v") == 0
+            if arguments:
+                assert run_poetry_cmd("build-lambda", arguments, "-v") == 0
+            else:
+                assert run_poetry_cmd("build-lambda", "-v") == 0
             for files_assertion in assert_files:
                 files_assertion()

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -195,6 +195,10 @@ def test_zip_builds(config: dict, args: dict, assert_files: list, tmp_path: Path
             assert run_poetry_cmd("add", "requests") == 0
             assert run_poetry_cmd("add", "pytest", "--group=test") == 0
             open(handler_file, "w").close()
+
+            if PYTHON_VER == "3.8":
+                config["pre-install-script"] = "pip install urllib3==1.26.7 -U -q"
+
             if config:
                 update_pyproject_toml(**config)
             arguments = " ".join(f"{k}={v}" for k, v in args.items())
@@ -216,6 +220,12 @@ def test_dir_builds(config: dict, args: dict, assert_files: list, tmp_path: Path
             assert run_poetry_cmd("add", "requests") == 0
             assert run_poetry_cmd("add", "pytest", "--group=test") == 0
             open(handler_file, "w").close()
+
+            if PYTHON_VER == "3.8":
+                config["pre-install-script"] = (
+                    "python3 -m pip install urllib3==1.26.7 -U -q"
+                )
+
             if config:
                 update_pyproject_toml(**config)
             arguments = " ".join(f"{k}={v}" for k, v in args.items())

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -22,8 +22,7 @@ from tests.utils import (
 def env_vars():
     if platform.system() == "Darwin":
         user = os.environ["USER"]
-        os.environ["DOCKER_HOST"] = f"unix:///Users/{
-            user}/.docker/run/docker.sock"
+        os.environ["DOCKER_HOST"] = f"unix:///Users/{user}/.docker/run/docker.sock"
     yield
 
 

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -197,15 +197,14 @@ def test_zip_builds(config: dict, args: dict, assert_files: list, tmp_path: Path
             open(handler_file, "w").close()
 
             if PYTHON_VER == "3.8":
-                config["pre-install-script"] = "python3 -m pip install urllib3==1.26.7 -U -q"
+                config["pre-install-script"] = (
+                    "python3 -m pip install urllib3==1.26.7 -U -q"
+                )
 
             if config:
                 update_pyproject_toml(**config)
             arguments = " ".join(f"{k}={v}" for k, v in args.items())
-            if arguments:
-                assert run_poetry_cmd("build-lambda", arguments, "-v") == 0
-            else:
-                assert run_poetry_cmd("build-lambda", "-v") == 0
+            assert run_poetry_cmd("build-lambda", arguments, "-v") == 0
             for files_assertion in assert_files:
                 files_assertion()
 
@@ -232,9 +231,6 @@ def test_dir_builds(config: dict, args: dict, assert_files: list, tmp_path: Path
             if config:
                 update_pyproject_toml(**config)
             arguments = " ".join(f"{k}={v}" for k, v in args.items())
-            if arguments:
-                assert run_poetry_cmd("build-lambda", arguments, "-v") == 0
-            else:
-                assert run_poetry_cmd("build-lambda", "-v") == 0
+            assert run_poetry_cmd("build-lambda", arguments, "-v") == 0
             for files_assertion in assert_files:
                 files_assertion()

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -198,7 +198,7 @@ def test_zip_builds(config: dict, args: dict, assert_files: list, tmp_path: Path
 
             if PYTHON_VER == "3.8":
                 config["pre-install-script"] = (
-                    "python3 -m pip install urllib3==1.26.7 -U -q"
+                    "python3 -m pip install urllib3<2.0 -U -q"
                 )
 
             if config:
@@ -225,7 +225,7 @@ def test_dir_builds(config: dict, args: dict, assert_files: list, tmp_path: Path
 
             if PYTHON_VER == "3.8":
                 config["pre-install-script"] = (
-                    "python3 -m pip install urllib3==1.26.7 -U -q"
+                    "python3 -m pip install urllib3<2.0 -U -q"
                 )
 
             if config:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,12 +2,26 @@ from __future__ import annotations
 
 import os
 import zipfile
+import subprocess
+from logging import Logger
+import sys
+from poetry_plugin_lambda_build.utils import run_cmd, remove_prefix
 
-from poetry_plugin_lambda_build.utils import run_python_cmd, remove_prefix
+
+def run_python_cmd(
+    *cmd: list[str],
+    logger: Logger | None = None,
+    stdout: int = subprocess.PIPE,
+    stderr: int = subprocess.PIPE,
+    **kwargs,
+) -> int:
+    return run_cmd(
+        sys.executable, *cmd, logger=logger, stdout=stdout, stderr=stderr, **kwargs
+    )
 
 
-def run_poetry_cmd(*args: list[str]) -> int:
-    return run_python_cmd("-m", "poetry", *args)
+def run_poetry_cmd(*cmd: list[str]) -> int:
+    return run_python_cmd("-m", "poetry", *cmd)
 
 
 def update_pyproject_toml(**kwargs):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import zipfile
 
-from poetry_plugin_lambda_build.utils import run_python_cmd
+from poetry_plugin_lambda_build.utils import run_python_cmd, remove_prefix
 
 
 def run_poetry_cmd(*args: list[str]) -> int:
@@ -20,7 +20,7 @@ def update_pyproject_toml(**kwargs):
 def assert_file_exists_in_dir(dirname: str, base_path: str = None, files: list = None):
     _files = []
     for _base, __, __files in os.walk(dirname):
-        _base = _base.removeprefix(dirname + "/")
+        _base = remove_prefix(_base, dirname + "/")
         _files += [os.path.join(_base, f) for f in __files]
     _files = set(_files)
 
@@ -39,7 +39,7 @@ def assert_file_exists_in_dir(dirname: str, base_path: str = None, files: list =
 def assert_file_not_exists_in_dir(dirname: str, files: list = None):
     _files = []
     for _base, __, __files in os.walk(dirname):
-        _base = _base.removeprefix(dirname + "/")
+        _base = remove_prefix(_base, dirname + "/")
         _files += [os.path.join(_base, f) for f in __files]
     _files = set(_files)
 


### PR DESCRIPTION
Changes:
* Changed Python testing version to 3.8 - in the future, we may be required to run multiple Python versions 
* `removepreifx` is not available on 3.8, replaced it with custom implementation
* Running builds on 3.8 is causing the following error

```
[ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with LibreSSL 2.8.3](https://stackoverflow.com/questions/76187256/importerror-urllib3-v2-0-only-supports-openssl-1-1-1-currently-the-ssl-modu)
```
I was able to suppress that by`pre-install-script="python3 -m pip install 'urllib3<2.0' -U -q"`


* Fixed formatting issues `pre-install-script`
* Modified if-statements for checking  `pre-install-script` value in recipies.py, on local builds pre-install-script was executed separately 
