### PR TITLE
When build-lambda is executed with the trusted-host, index-url or ext…

### DIFF
--- a/poetry_plugin_lambda_build/requirements.py
+++ b/poetry_plugin_lambda_build/requirements.py
@@ -210,12 +210,12 @@ class RequirementsExporter:
             url = repository.authenticated_url
             parsed_url = urllib.parse.urlsplit(url)
             if parsed_url.scheme == "http":
-                args += ["--trusted-host", f"{parsed_url.netloc}\n"]
+                args += ["--trusted-host", f" {parsed_url.netloc}\n"]
             if (
                 not has_pypi_repository
                 and repository is self._poetry.pool.repositories[0]
             ):
-                args += ["--index-url", f"{url}\n"]
+                args += ["--index-url", f" {url}\n"]
             else:
-                args += ["--extra-index-url", f"{url}\n"]
+                args += ["--extra-index-url", f" {url}\n"]
         return args

--- a/poetry_plugin_lambda_build/requirements.py
+++ b/poetry_plugin_lambda_build/requirements.py
@@ -185,7 +185,7 @@ class RequirementsExporter:
         content += "\n"
 
         if indexes and self._with_urls:
-            indexes_header = "".join(self.export_indexes())
+            indexes_header = " ".join(self.export_indexes())
 
             if indexes_header:
                 content = indexes_header + "\n" + content
@@ -210,12 +210,12 @@ class RequirementsExporter:
             url = repository.authenticated_url
             parsed_url = urllib.parse.urlsplit(url)
             if parsed_url.scheme == "http":
-                args += ["--trusted-host", f" {parsed_url.netloc}\n"]
+                args += ["--trusted-host", f"{parsed_url.netloc}\n"]
             if (
                 not has_pypi_repository
                 and repository is self._poetry.pool.repositories[0]
             ):
-                args += ["--index-url", f" {url}\n"]
+                args += ["--index-url", f"{url}\n"]
             else:
-                args += ["--extra-index-url", f" {url}\n"]
+                args += ["--extra-index-url", f"{url}\n"]
         return args


### PR DESCRIPTION
…ra-index-url flags it fails because of the lack of a space during concatenation