### PR TITLE
exclude hashes when exporting VCS requirements

### DIFF
--- a/poetry_plugin_lambda_build/requirements.py
+++ b/poetry_plugin_lambda_build/requirements.py
@@ -161,7 +161,7 @@ class RequirementsExporter:
             ):
                 indexes.add(package.source_url.rstrip("/"))
 
-            if package.files and self._with_hashes:
+            if package.files and self._with_hashes and not is_direct_remote_reference:
                 hashes = []
                 for f in package.files:
                     h = f["hash"]

--- a/poetry_plugin_lambda_build/requirements.py
+++ b/poetry_plugin_lambda_build/requirements.py
@@ -38,7 +38,7 @@ class RequirementsExporter:
     def __init__(self, poetry: Poetry, io: IO, groups: list[str] | None = None) -> None:
         self._poetry = poetry
         self._io = io
-        self._with_hashes = False
+        self._with_hashes = True
         self._with_credentials = False
         self._with_urls = True
         self._extras: Collection[NormalizedName] = ()

--- a/poetry_plugin_lambda_build/requirements.py
+++ b/poetry_plugin_lambda_build/requirements.py
@@ -38,7 +38,7 @@ class RequirementsExporter:
     def __init__(self, poetry: Poetry, io: IO, groups: list[str] | None = None) -> None:
         self._poetry = poetry
         self._io = io
-        self._with_hashes = True
+        self._with_hashes = False
         self._with_credentials = False
         self._with_urls = True
         self._extras: Collection[NormalizedName] = ()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-plugin-lambda-build"
-version = "2.1.0"
+version = "2.1.1"
 description = "The plugin for poetry that allows you to build zip packages suited for serverless deployment like AWS Lambda, Google App Engine, Azure App Service, and more..."
 authors = ["Michal Murawski <mmurawski777@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
This should address [this issue](https://github.com/micmurawski/poetry-plugin-lambda-build/issues/54) where the plugin fails to build poetry projects with dependencies installed via VCS urls such as git+ssh. 

The nature of the issue is that the plugin includes a custom exporter for dumping poetry dependencies to a requirements.txt file. This file is built with hashes which allow pip to ensure the same code that the requirements.txt file was built from is consistently used. The plugin then utilizes pip to install those dependencies in the generated requirements.txt file but that command fails because pip is unable to verify the hashes for VCS urls. 

The fix works by excluding hashes for dependencies installed via VCS or other URLs.